### PR TITLE
ADDING ENVIRONMENT VARIABLE TO CONFIGURE MONIT CYCLE INTERVAL FEATURE

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ Besides, you can customize the configuration in several ways:
 
 Monit is installed with the default configuration and some parameters can be overrided with env variables:
 
+- MONIT_DAEMON="60"             # Length of monit "cycles"
 - MONIT_PORT="2812"             # Port to listen monit httpd service
 - MONIT_ALLOW="localhost"       # Rule to allow connections to the httpd port
 - MONIT_ARGS="-I"               # Monit exec args

--- a/root/opt/monit/bin/monit-start.sh
+++ b/root/opt/monit/bin/monit-start.sh
@@ -20,12 +20,13 @@ fi
 
 chmod 700 ${MONIT_HOME}/etc/monitrc
 
+MONIT_DAEMON=${MONIT_DAEMON:-"60"}
 MONIT_PORT=${MONIT_PORT:-"2812"}
 MONIT_ALLOW=${MONIT_ALLOW:-"localhost"}
 MONIT_ARGS=${MONIT_ARGS:-"-I"}
 
 cat << EOF > ${MONIT_HOME}/etc/conf.d/basic
-set daemon 60
+set daemon ${MONIT_DAEMON}
 set logfile ${MONIT_HOME}/log/monit.log
 set pidfile ${MONIT_HOME}/log/monit.pid
 set statefile ${MONIT_HOME}/log/monit.state


### PR DESCRIPTION
Some people might want shorter or longer cycle lengths, myself included. So, I thought I'd add this to the upstream. 

- README.md also updated
- MONIT_DAEMON is environment variable used
- original default value of 60 is preserved if absent